### PR TITLE
Add --bytes argument to get speed in MB/s

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ speedtest-cli-3 is written for use with Python 3
 ## Usage
 
     $ speedtest-cli -h
-    usage: speedtest-cli [-h] [--share] [--simple] [--list] [--server SERVER]
+    usage: speedtest-cli [-h] [--share] [--simple] [--list] [--bytes] [--server SERVER]
     
     Command line interface for testing internet bandwidth using speedtest.net.
     --------------------------------------------------------------------------
@@ -23,4 +23,5 @@ speedtest-cli-3 is written for use with Python 3
                        results image
       --simple         Suppress verbose output, only show basic information
       --list           Display a list of speedtest.net servers sorted by distance
+      --bytes          Display speeds in MBytes/s (instead of Mbit/s)
       --server SERVER  Specify a server ID to test against

--- a/speedtest-cli
+++ b/speedtest-cli
@@ -290,6 +290,7 @@ def speedtest():
                         help='Display a list of speedtest.net servers '
                              'sorted by distance')
     parser.add_argument('--server', help='Specify a server ID to test against')
+    parser.add_argument('--bytes', action='store_true', help='Show speed in MB per second')
 
     options = parser.parse_args()
     if isinstance(options, tuple):
@@ -341,6 +342,10 @@ def speedtest():
     else:
         print 'Ping: %(latency)s ms' % best
 
+    unit = 'bits'
+    if args.bytes:
+        unit = 'B'
+
     sizes = [350, 500, 750, 1000, 1500, 2000, 2500, 3000, 3500, 4000]
     urls = []
     for size in sizes:
@@ -352,7 +357,11 @@ def speedtest():
     dlspeed = downloadSpeed(urls, args.simple)
     if not args.simple:
         print
-    print 'Download: %0.2f Mbit/s' % ((dlspeed / 1000 / 1000) * 8)
+
+    dlspeed = dlspeed / 1000 / 1000
+    if not args.bytes:
+        dlspeed = dlspeed * 8
+    print 'Download: %0.2f M%s/s' % (dlspeed, unit)
 
     sizesizes = [int(.25 * 1000 * 1000), int(.5 * 1000 * 1000)]
     sizes = []
@@ -364,7 +373,11 @@ def speedtest():
     ulspeed = uploadSpeed(best['url'], sizes, args.simple)
     if not args.simple:
         print
-    print 'Upload: %0.2f Mbit/s' % ((ulspeed / 1000 / 1000) * 8)
+
+    ulspeed = ulspeed / 1000 / 1000
+    if not args.bytes:
+        ulspeed = ulspeed * 8
+    print 'Upload: %0.2f M%s/s' % (ulspeed, unit)
 
     if args.share:
         dlspeedk = int(round((dlspeed / 1000) * 8, 0))

--- a/speedtest-cli-3
+++ b/speedtest-cli-3
@@ -272,6 +272,7 @@ def speedtest():
                         help='Display a list of speedtest.net servers '
                              'sorted by distance')
     parser.add_argument('--server', help='Specify a server ID to test against')
+    parser.add_argument('--bytes', action='store_true', help='Show speed in MB per second')
     args = parser.parse_args()
 
     if not args.simple:
@@ -318,6 +319,10 @@ def speedtest():
     else:
         print('Ping: %(latency)s ms' % best)
 
+    unit = 'bits'
+    if args.bytes:
+        unit = 'B'
+
     sizes = [350, 500, 750, 1000, 1500, 2000, 2500, 3000, 3500, 4000]
     urls = []
     for size in sizes:
@@ -329,7 +334,11 @@ def speedtest():
     dlspeed = downloadSpeed(urls, args.simple)
     if not args.simple:
         print()
-    print('Download: %0.2f Mbit/s' % ((dlspeed / 1000 / 1000) * 8))
+
+    dlspeed = dlspeed / 1000 / 1000
+    if not args.bytes:
+        dlspeed = dlspeed * 8
+    print('Download: %0.2f M%s/s' % (dlspeed, unit))
 
     sizesizes = [int(.25 * 1000 * 1000), int(.5 * 1000 * 1000)]
     sizes = []
@@ -341,7 +350,11 @@ def speedtest():
     ulspeed = uploadSpeed(best['url'], sizes, args.simple)
     if not args.simple:
         print()
-    print('Upload: %0.2f Mbit/s' % ((ulspeed / 1000 / 1000) * 8))
+
+    ulspeed = ulspeed / 1000 / 1000
+    if not args.bytes:
+        ulspeed = ulspeed * 8
+    print('Upload: %0.2f M%s/s' % (ulspeed, unit))
 
     if args.share:
         dlspeedk = int(round((dlspeed / 1000) * 8, 0))


### PR DESCRIPTION
The :iphone: iPhone app has this feature quite nicely. I prefer to get 'real values' as it is not obvious what '25 Mbits/s' really means unless I decide to divide that by 8 as I read it.

While the iPhone app uses kB/s, I think it's better to wait till a better humanisation method is added for sizing before making the switch. So this just keeps it to MB/s.

I did not change the section to get the image for this because I do not know if the API can retrieve images like the one the iPhone app does. I suppose I could sniff it later to find out. :smirk_cat:

![iPhone app screenshot](http://www.speedtest.net/iphone/530979727.png)
