### PR TITLE
Add option to use binary prefixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,4 +24,6 @@ speedtest-cli-3 is written for use with Python 3
       --simple         Suppress verbose output, only show basic information
       --list           Display a list of speedtest.net servers sorted by distance
       --bytes          Display speeds in MBytes/s (instead of Mbit/s)
+      --ib             Use IEC binary prefixes (MiB, etc)
+                       http://en.wikipedia.org/wiki/Binary_prefix
       --server SERVER  Specify a server ID to test against

--- a/speedtest-cli
+++ b/speedtest-cli
@@ -291,6 +291,7 @@ def speedtest():
                              'sorted by distance')
     parser.add_argument('--server', help='Specify a server ID to test against')
     parser.add_argument('--bytes', action='store_true', help='Show speed in MB per second')
+    parser.add_argument('--ib', action='store_true', help='Use IEC binary prefixes (MiB, etc)')
 
     options = parser.parse_args()
     if isinstance(options, tuple):
@@ -343,8 +344,13 @@ def speedtest():
         print 'Ping: %(latency)s ms' % best
 
     unit = 'bits'
+    size_divisor = 1000
+
     if args.bytes:
         unit = 'B'
+    if args.ib:
+        unit = 'i' + unit
+        size_divisor = 1024
 
     sizes = [350, 500, 750, 1000, 1500, 2000, 2500, 3000, 3500, 4000]
     urls = []
@@ -358,12 +364,12 @@ def speedtest():
     if not args.simple:
         print
 
-    dlspeed = dlspeed / 1000 / 1000
+    dlspeed = dlspeed / size_divisor / size_divisor
     if not args.bytes:
         dlspeed = dlspeed * 8
     print 'Download: %0.2f M%s/s' % (dlspeed, unit)
 
-    sizesizes = [int(.25 * 1000 * 1000), int(.5 * 1000 * 1000)]
+    sizesizes = [int(.25 * size_divisor * size_divisor), int(.5 * size_divisor * size_divisor)]
     sizes = []
     for size in sizesizes:
         for i in xrange(0, 25):
@@ -374,11 +380,12 @@ def speedtest():
     if not args.simple:
         print
 
-    ulspeed = ulspeed / 1000 / 1000
+    ulspeed = ulspeed / size_divisor / size_divisor
     if not args.bytes:
         ulspeed = ulspeed * 8
     print 'Upload: %0.2f M%s/s' % (ulspeed, unit)
 
+    # --ib option does not affect this part
     if args.share:
         dlspeedk = int(round((dlspeed / 1000) * 8, 0))
         ping = int(round(best['latency'], 0))

--- a/speedtest-cli-3
+++ b/speedtest-cli-3
@@ -273,6 +273,7 @@ def speedtest():
                              'sorted by distance')
     parser.add_argument('--server', help='Specify a server ID to test against')
     parser.add_argument('--bytes', action='store_true', help='Show speed in MB per second')
+    parser.add_argument('--ib', action='store_true', help='Use IEC binary prefixes (MiB, etc)')
     args = parser.parse_args()
 
     if not args.simple:
@@ -320,8 +321,13 @@ def speedtest():
         print('Ping: %(latency)s ms' % best)
 
     unit = 'bits'
+    size_divisor = 1000
+
     if args.bytes:
         unit = 'B'
+    if args.ib:
+        unit = 'i' + unit
+        size_divisor = 1024
 
     sizes = [350, 500, 750, 1000, 1500, 2000, 2500, 3000, 3500, 4000]
     urls = []
@@ -335,12 +341,12 @@ def speedtest():
     if not args.simple:
         print()
 
-    dlspeed = dlspeed / 1000 / 1000
+    dlspeed = dlspeed / size_divisor / size_divisor
     if not args.bytes:
         dlspeed = dlspeed * 8
     print('Download: %0.2f M%s/s' % (dlspeed, unit))
 
-    sizesizes = [int(.25 * 1000 * 1000), int(.5 * 1000 * 1000)]
+    sizesizes = [int(.25 * size_divisor * size_divisor), int(.5 * size_divisor * size_divisor)]
     sizes = []
     for size in sizesizes:
         for i in range(0, 25):
@@ -351,11 +357,12 @@ def speedtest():
     if not args.simple:
         print()
 
-    ulspeed = ulspeed / 1000 / 1000
+    ulspeed = ulspeed / size_divisor / size_divisor
     if not args.bytes:
         ulspeed = ulspeed * 8
     print('Upload: %0.2f M%s/s' % (ulspeed, unit))
 
+    # --ib option does not affect this part
     if args.share:
         dlspeedk = int(round((dlspeed / 1000) * 8, 0))
         ping = int(round(best['latency'], 0))


### PR DESCRIPTION
Get a more realistic speed as most file managers and apps still assume binary sizes (powers of 1024). Not on by default.

http://en.wikipedia.org/wiki/Binary_prefix
