### PR TITLE
perform ICMP pings on posix systems

### DIFF
--- a/speedtest_cli.py
+++ b/speedtest_cli.py
@@ -316,19 +316,24 @@ def getBestServer(servers):
 
     results = {}
     for server in servers:
-        cum = 0
         url = os.path.dirname(server['url'])
-        for i in range(0, 3):
-            uh = urlopen('%s/latency.txt' % url)
-            start = time.time()
-            text = uh.read().strip()
-            total = time.time() - start
-            if int(uh.code) == 200 and text == 'test=test'.encode():
-                cum += total
-            else:
-                cum += 3600
-            uh.close()
-        avg = round((cum / 3) * 1000000, 3)
+        if os.name == 'posix':
+            cmd = 'ping -c 3 ' + url.split('/')[2] + ' | tail -n 1'
+            pingoutput = os.popen(cmd).read()
+            avg = pingoutput.split('/')[4]
+        else:
+            cum = 0
+            for i in range(0, 3):
+                uh = urlopen('%s/latency.txt' % url)
+                start = time.time()
+                text = uh.read().strip()
+                total = time.time() - start
+                if int(uh.code) == 200 and text == 'test=test'.encode():
+                    cum += total
+                else:
+                    cum += 3600
+                uh.close()
+            avg = round((cum / 3) * 1000000, 3)
         results[avg] = server
 
     fastest = sorted(results.keys())[0]


### PR DESCRIPTION
The script was regularly returning 600ms+ pings, when the Speedtest site gives me ~20ms. I suspect this to be due to the current time module 'stopwatch' scheme. It's possible that the times may scale, and the fastest server may remain the same, but who knows how much of the overhead is due to Python and how much is due to the network.

ICMP sockets cannot be created without root access, so the simplest implementation of a true ICMP ping that I found is to just run it in a system shell. I've tested this on Linux (Debian) and Mac (10.8.4), as well as Python 2.4, 2.7 and 3.3. I would have done the Windows implementation too if I had easy access to a machine.

This change has brought my fastest ping down from 694ms to 21ms.
