### PR TITLE
Add timeout and no upload options(again)

### DIFF
--- a/speedtest_cli.py
+++ b/speedtest_cli.py
@@ -465,17 +465,21 @@ def speedtest():
     parser.add_argument('--version', action='store_true',
                         help='Show the version number and exit')
     parser.add_argument('--no-upload', action='store_true', help='no upload speed test')
+    parser.add_argument('--timeout', type=int, default=30, help='socket timeout in seconds(default to 30)')
 
     options = parser.parse_args()
     if isinstance(options, tuple):
         args = options[0]
     else:
         args = options
+
     del options
 
     # Print the version and exit
     if args.version:
         version()
+
+    socket.setdefaulttimeout(args.timeout)
 
     # If specified bind to a specific IP address
     if args.source:


### PR DESCRIPTION
1, no-upload option will skip upload speed test. This could be useful when there is little need to do uploading.
2. timeout option will set the defaulttimeout for socket. The default timeout(None) is too long when bandwidth is low.

This is a duplicate of #48, but that pr is for master branch.
