### PR TITLE
add log option

### DIFF
--- a/speedtest_cli.py
+++ b/speedtest_cli.py
@@ -676,7 +676,7 @@ def speedtest():
             found = imp.find_module(args.resultlog)
             logmodule = imp.load_module(args.resultlog, found)
         except ImportError:
-            print_('Load log module (%s) failed.' % args.resultlog),
+            print_('Log module (%s) failed. Not logging.' % args.resultlog),
             sys.exit(1)
 
         result = {'dlspeed': dlspeed, 'ulspeed': ulspeed}


### PR DESCRIPTION
Add the command-line option for an external Python class/module to be used as a logger.

Send the config and best (best server) objects along with dlspeed and ulspeed to the logger and allow it to format, munge, relay, etc. as desired. This seemed like the best option without a huge investment of time and huge amount of code.

While this comes close to the prohibition on "external" libraries, it is _not_ a requirement, just an option.
