### PR TITLE
Use HTTPS for speedtest.net URLs

### DIFF
--- a/speedtest_cli.py
+++ b/speedtest_cli.py
@@ -319,7 +319,7 @@ def getConfig():
     we are interested in
     """
 
-    request = build_request('http://www.speedtest.net/speedtest-config.php')
+    request = build_request('https://www.speedtest.net/speedtest-config.php')
     uh = urlopen(request)
     configxml = []
     while 1:
@@ -357,7 +357,7 @@ def closestServers(client, all=False):
     distance
     """
 
-    url = 'http://www.speedtest.net/speedtest-servers-static.php'
+    url = 'https://www.speedtest.net/speedtest-servers-static.php'
     request = build_request(url)
     uh = urlopen(request)
     serversxml = []
@@ -684,8 +684,8 @@ def speedtest():
                              (ping, ulspeedk, dlspeedk, '297aae72'))
                             .encode()).hexdigest()]
 
-        headers = {'Referer': 'http://c.speedtest.net/flash/speedtest.swf'}
-        request = build_request('http://www.speedtest.net/api/api.php',
+        headers = {'Referer': 'https://c.speedtest.net/flash/speedtest.swf'}
+        request = build_request('https://www.speedtest.net/api/api.php',
                                 data='&'.join(apiData).encode(),
                                 headers=headers)
         f = urlopen(request)
@@ -703,7 +703,7 @@ def speedtest():
             print_('Could not submit results to speedtest.net')
             sys.exit(1)
 
-        print_('Share results: http://www.speedtest.net/result/%s.png' %
+        print_('Share results: https://www.speedtest.net/result/%s.png' %
                resultid[0])
 
 


### PR DESCRIPTION
HTTP is insecure – any attacker with a privileged network position could intercept the request and possibly drop/rewrite it. HTTPS makes it much harder for anyone to do so. 

[Some more reasons](https://konklone.com/post/switch-to-https-now-for-free):

* SSL’s not perfect, but we need to [make surveillance as expensive as possible](http://www.theguardian.com/world/2013/sep/05/nsa-how-to-remain-secure-surveillance).
* For privacy not to be suspicious, [privacy should be on by default](http://www.tbray.org/ongoing/When/201x/2012/12/02/HTTPS).