### PR TITLE
Added CSV mode 

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -91,6 +91,7 @@ Usage
       --mini MINI        URL of the Speedtest Mini server
       --source SOURCE    Source IP address to bind to
       --timeout TIMEOUT  HTTP timeout in seconds. Default 10
+      --csv CSV          Write output to CSV file
       --version          Show the version number and exit
 
 Inconsistency

--- a/speedtest-cli.1
+++ b/speedtest-cli.1
@@ -58,6 +58,12 @@ URL of the Speedtest Mini server
 Source IP address to bind to
 .RE
 
+\fB\-\-csv CSV\fR
+.RS
+CSV file to write to
+.RE
+
+
 \fB\-\-version\fR
 .RS
 Show the version number and exit

--- a/speedtest_cli.py
+++ b/speedtest_cli.py
@@ -760,7 +760,7 @@ def speedtest():
 
                 csvwriter.writerow({'Test server': server, 
                                     'Date/Time': current_time, 
-                                    'Latency': ping,
+                                    'Latency (ms)': ping,
                                     'Dowload Speed (Kb/s)': dlspeedk, 
                                     'Upload Speed (Kb/s)': ulspeedk
                                      })

--- a/speedtest_cli.py
+++ b/speedtest_cli.py
@@ -736,34 +736,34 @@ def speedtest():
     print_('Upload: %0.2f M%s/s' %
            ((ulspeed / 1000 / 1000) * args.units[1], args.units[0]))
 
-    if args.csv: 
+    if args.csv:
         filename = args.csv
         file_exists = os.path.isfile(filename)
-
         try:
-            with open(filename, 'ab+') as csvfile:
+            csvfile = open(filename, 'ab+')
+            try:
 
-                headers = ['Test server', 'Date/Time', 'Latency (ms)', 
-                           'Dowload Speed (Kb/s)', 'Upload Speed (Kb/s)']
-                csvwriter = csv.DictWriter(csvfile, delimiter=';',
-                                           lineterminator='\n',fieldnames=headers)
+                    headers = ['Test server', 'Date/Time', 'Latency (ms)',
+                               'Dowload Speed (Kb/s)', 'Upload Speed (Kb/s)']
+                    csvwriter = csv.DictWriter(csvfile, delimiter=';',
+                                               lineterminator='\n',
+                                               fieldnames=headers)
 
-                server = '%(sponsor)s (%(name)s) [%(d)0.2f km]' % best
-                current_time = datetime.datetime.now().isoformat()
-                dlspeedk = int(round((dlspeed / 1000) * 8, 0))
-                ping = float(round(best['latency'], 2))
-                ulspeedk = int(round((ulspeed / 1000) * 8, 0))
+                    server = '%(sponsor)s (%(name)s) [%(d)0.2f km]' % best
+                    current_time = datetime.datetime.now().isoformat()
+                    dlspeedk = int(round((dlspeed / 1000) * 8, 0))
+                    ping = float(round(best['latency'], 2))
+                    ulspeedk = int(round((ulspeed / 1000) * 8, 0))
 
+                    if not file_exists:
+                        csvwriter.writeheader()
 
-                if not file_exists:
-                    csvwriter.writeheader()            
-
-                csvwriter.writerow({'Test server': server, 
-                                    'Date/Time': current_time, 
-                                    'Latency (ms)': ping,
-                                    'Dowload Speed (Kb/s)': dlspeedk, 
-                                    'Upload Speed (Kb/s)': ulspeedk
-                                     })
+                    csvwriter.writerow({'Test server': server,
+                                        'Date/Time': current_time,
+                                        'Latency (ms)': ping,
+                                        'Dowload Speed (Kb/s)': dlspeedk,
+                                        'Upload Speed (Kb/s)': ulspeedk})
+            finally:
                 csvfile.close()
         except IOError:
             print_("Unable to write CSV file")

--- a/speedtest_cli.py
+++ b/speedtest_cli.py
@@ -750,7 +750,8 @@ def speedtest():
                                                fieldnames=headers)
 
                     server = '%(sponsor)s (%(name)s) [%(d)0.2f km]' % best
-                    current_time = datetime.datetime.now().isoformat()
+                    current_time = datetime.datetime.now().strftime(
+                        "%Y/%m/%d %H:%M:%S")
                     dlspeedk = int(round((dlspeed / 1000) * 8, 0))
                     ping = float(round(best['latency'], 2))
                     ulspeedk = int(round((ulspeed / 1000) * 8, 0))


### PR DESCRIPTION
I'm happy to make this sugestion as my first GitHub contribution to a project :-).
I've added a --csv *filename* mode that write speedtest results to that filename.

    speedtest-cli --csv bandwith_report.csv

If the file doesn't extists it generates a new one with a header. If it cannot write launches an error. This is a sample result:

    Test server;Date/Time;Latency;Dowload Speed (Kb/s);Upload Speed (Kb/s)
    Grupo TVHoradada (Pilar De La Horadada) [87.32 km];2015-07-06T11:28:32.013159;64.8;59847;25499
    Grupo TVHoradada (Pilar De La Horadada) [87.32 km];2015-07-06T11:29:30.652184;62.22;59636;25775
    TVAlmansa S.L. (Almansa) [50.87 km];2015-07-06T11:32:33.344205;85.19;60257;24798
    TVAlmansa S.L. (Almansa) [50.87 km];2015-07-06T11:33:29.556000;62.26;58992;25111
    ...

You can install a cron jon to execute the test each hour for example and store results for future analysis or graphic.

    $crontab -e
    0 */1 * * * /home/myuser/speedtest-cli --csv bandwith_report.csv >> /dev/null

Edited:
Standar output is been redirected to /dev/null in crontab. It could be interesting to add a --silent mode to use in combination with --csv
