### PR TITLE
Add collectd-exec support to speedtest-cli.

### DIFF
--- a/speedtest-cli.1
+++ b/speedtest-cli.1
@@ -38,6 +38,16 @@ Generate and provide a URL to the speedtest.net share results image
 Suppress verbose output, only show basic information
 .RE
 
+\fB\-\-collectd\fR
+.RS
+Emit output compatible with the \fBcollectd-exec(5)\fR collectd script.
+.RE
+
+\fB\-\-collectd_interval COLLECTD_INTERVAL\fR
+.RS
+The collection interval (in seconds) to be used when using the \fBcollectd-exec(5)\fR script.
+.RE
+
 \fB\-\-list\fR
 .RS
 Display a list of speedtest.net servers sorted by distance

--- a/speedtest_cli.py
+++ b/speedtest_cli.py
@@ -686,9 +686,9 @@ def speedtest():
                    '%(latency)s ms' % best)
     else:
         if args.collectd:
-            print_('PUTVAL "%s/speedtest/latency-latency_ms" interval=%d N:%d' %
-                   (socket.gethostname(), args.collectd_interval,
-                    best['latency']))
+            print_('PUTVAL "%s/speedtest/latency-latency_ms" '
+                   'interval=%d N:%d' % (socket.gethostname(),
+                   args.collectd_interval, best['latency']))
         else:
             print_('Ping: %(latency)s ms' % best)
 
@@ -779,6 +779,7 @@ def speedtest():
     # Sleep before next cycle if collectd requested
     if args.collectd:
         time.sleep(args.collectd_interval)
+
 
 def main():
     try:


### PR DESCRIPTION
This patch introduces collectd-exec style output to speedtest-cli. With it, it's possible to configure collectd's Exec script to periodically run speedtest-cli and produce graphs of your network speed.

To use this feature, just make sure the following exists in /etc/collectd.conf:

```
LoadPlugin exec                                                                                     
<Plugin exec>                                                                                       
        Exec run_as_username "/path/to/speedtest_cli.py" "--collectd" "--collectd_interval=600"
</Plugin>
```

This will collect up/down speeds and latency every 10 minutes.
