### PR TITLE
Add the --use_interface_counters option.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -97,6 +97,11 @@ Usage
       --timeout TIMEOUT  HTTP timeout in seconds. Default 10
       --secure           Use HTTPS instead of HTTP when communicating with
                          speedtest.net operated servers
+      --use_interface_counters USE_INTERFACE_COUNTERS
+                         Use the kernel counters for the specified network
+                         interface to calculate the total number of bytes
+                         transmitted/received (Linux only).
+                         --version             Show the version number and exit
       --version          Show the version number and exit
 
 Inconsistency

--- a/speedtest-cli.1
+++ b/speedtest-cli.1
@@ -58,6 +58,15 @@ URL of the Speedtest Mini server
 Source IP address to bind to
 .RE
 
+\fB\-\-use_interface_counters INTF\fR
+.RS
+With this option the program uses the kernel counters for interface
+"intf" to calculate the number of bytes transferred. This option is
+useful when running this program on a computer that is the gateway
+to the Internet, as it will include the bandwidth used by every user
+of the system and thus provide more accurate bandwidth figures.
+.RE
+
 \fB\-\-version\fR
 .RS
 Show the version number and exit


### PR DESCRIPTION
Add the "--use_interface_counters" option. With this option, speedtest_cli reads the total number of bytes transferred from the interface counters (using the sys filesystem). This provides more accurate total bandwidth results, since it also accounts for other users/processes using the interface. This option is useful when running speedtest-cli on a machine that routes all Internet traffic for a given site, or for machines whose only use is to talk to the internet via their primary interface (single computer at home).