### PR TITLE
Correct average latency calculation in best server determination.

### DIFF
--- a/speedtest_cli.py
+++ b/speedtest_cli.py
@@ -522,7 +522,7 @@ def getBestServer(servers):
             else:
                 cum.append(3600)
             h.close()
-        avg = round((sum(cum) / 6) * 1000, 3)
+        avg = round((sum(cum) / 3) * 1000, 3)
         results[avg] = server
     fastest = sorted(results.keys())[0]
     best = results[fastest]


### PR DESCRIPTION
Reverts part of commit c1b9a0d. I guess some exploratory or debugging edits
made it into the commit.

Three samples are run, summed, and divided by six. It should be three.

As a result, the latency results were halved. The "best" server was still
chosen but the ping time displayed was half of the real average result.