### PR TITLE
Return  DL/UL speed from speedtest()

### DIFF
--- a/speedtest_cli.py
+++ b/speedtest_cli.py
@@ -547,7 +547,7 @@ def version():
     raise SystemExit(__version__)
 
 
-def speedtest(**kwargs):
+def speedtest():
     """Run the full speedtest.net test"""
 
     global shutdown_event, source, scheme
@@ -715,7 +715,7 @@ def speedtest(**kwargs):
             urls.append('%s/random%sx%s.jpg' %
                         (os.path.dirname(best['url']), size, size))
     if not args.simple:
-        print_('Testing download speed PJW', end='')
+        print_('Testing download speed ', end='')
     dlspeed = downloadSpeed(urls, args.simple)
     if not args.simple:
         print_()

--- a/speedtest_cli.py
+++ b/speedtest_cli.py
@@ -547,7 +547,7 @@ def version():
     raise SystemExit(__version__)
 
 
-def speedtest():
+def speedtest(**kwargs):
     """Run the full speedtest.net test"""
 
     global shutdown_event, source, scheme
@@ -715,7 +715,7 @@ def speedtest():
             urls.append('%s/random%sx%s.jpg' %
                         (os.path.dirname(best['url']), size, size))
     if not args.simple:
-        print_('Testing download speed', end='')
+        print_('Testing download speed PJW', end='')
     dlspeed = downloadSpeed(urls, args.simple)
     if not args.simple:
         print_()
@@ -783,6 +783,13 @@ def speedtest():
 
         print_('Share results: %s://www.speedtest.net/result/%s.png' %
                (scheme, resultid[0]))
+
+    speeds = {
+        'DL': (dlspeed / 1000 / 1000) * args.units[1],
+        'UL': (ulspeed / 1000 / 1000) * args.units[1]
+        }
+
+    return speeds
 
 
 def main():


### PR DESCRIPTION
Really simple addition that just returns the UL and DL speeds as a dict for use if other programs import speedtest and just want to use the data as a library instead of running as a stand alone program.