### PR TITLE
Remove bytes string characters ('b' and quotation marks) (Fix #192)

### DIFF
--- a/speedtest_cli.py
+++ b/speedtest_cli.py
@@ -704,7 +704,7 @@ def speedtest():
 
     if not args.simple:
         print_(('Hosted by %(sponsor)s (%(name)s) [%(d)0.2f km]: '
-               '%(latency)s ms' % best).encode('utf-8', 'ignore'))
+               '%(latency)s ms' % best))
     else:
         print_('Ping: %(latency)s ms' % best)
 


### PR DESCRIPTION
Remove bytes string characters ('b' and quotation marks) from 'Hosted by' output due to unneeded UTF-8 encoding/decoding.
Example:

*Current*:
```
[...]
Selecting best server based on latency...
b'Hosted by Avira B.V. (Doetinchem) [93.28 km]: 13.316 ms'
Testing download speed 
[...]
```

*New*:
```
[...]
Selecting best server based on latency...
Hosted by KomMITT Ratingen (Ratingen) [12.97 km]: 11.528 ms
Testing download speed 
[...]
```

I couldn't find any issues with UTF-8 hoster names.