### PR TITLE
Fix output of unicode strings with Python 3

### DIFF
--- a/speedtest_cli.py
+++ b/speedtest_cli.py
@@ -108,6 +108,8 @@ except ImportError:
         def write(data):
             if not isinstance(data, basestring):
                 data = str(data)
+            if isinstance(data, unicode):
+                data = data.encode('utf-8', 'ignore')
             fp.write(data)
 
         want_unicode = False
@@ -635,7 +637,7 @@ def speedtest():
                 line = ('%(id)4s) %(sponsor)s (%(name)s, %(country)s) '
                         '[%(d)0.2f km]' % server)
                 serverList.append(line)
-            print_('\n'.join(serverList).encode('utf-8', 'ignore'))
+            print_('\n'.join(serverList))
             sys.exit(0)
     else:
         servers = closestServers(config['client'])
@@ -703,8 +705,8 @@ def speedtest():
         best = getBestServer(servers)
 
     if not args.simple:
-        print_(('Hosted by %(sponsor)s (%(name)s) [%(d)0.2f km]: '
-               '%(latency)s ms' % best).encode('utf-8', 'ignore'))
+        print_('Hosted by %(sponsor)s (%(name)s) [%(d)0.2f km]: '
+               '%(latency)s ms' % best)
     else:
         print_('Ping: %(latency)s ms' % best)
 


### PR DESCRIPTION
With the current code, Python 3 prints `bytes` instead of `str`, which causes the output to be broken  (this is especially problematic  for `--list` because the newlines are not interpreted).
I tested my fix with Python 2.4, 2.7 and 3.5. It should not break anything for old versions.

This passes pep8  and pyflakes. I don't have a pypy install to test with but I don't see why it would fail as it's fairly trivial.