### PR TITLE
Fix up Speedtest mini server compatibility with python3

### DIFF
--- a/speedtest_cli.py
+++ b/speedtest_cli.py
@@ -676,7 +676,7 @@ def speedtest():
                 except:
                     pass
                 else:
-                    data = f.read().strip()
+                    data = f.read().strip().decode('utf-8')
                     if (f.code == 200 and
                             len(data.splitlines()) == 1 and
                             re.match('size=[0-9]', data)):
@@ -704,7 +704,7 @@ def speedtest():
 
     if not args.simple:
         print_(('Hosted by %(sponsor)s (%(name)s) [%(d)0.2f km]: '
-               '%(latency)s ms' % best).encode('utf-8', 'ignore'))
+               '%(latency)s ms' % best))
     else:
         print_('Ping: %(latency)s ms' % best)
 


### PR DESCRIPTION
This fixes up a binary conversion error when matching for the required size in the speedtest download on mini servers due to the nature of how python3 does urllib downloads.

Error in python3 before the patch:
```
Traceback (most recent call last):
  File "./speedtest_cli.py", line 764, in <module>
    main()
  File "./speedtest_cli.py", line 758, in main
    speedtest()
  File "./speedtest_cli.py", line 642, in speedtest
    re.match('size=[0-9]', data)):
  File "/usr/lib/python3.5/re.py", line 163, in match
    return _compile(pattern, flags).match(string)
TypeError: cannot use a string pattern on a bytes-like object
```

I have tested this on an ArchLinux install of python, both versions Python 2.7.11 and Python 3.5.1

Line 707 was due to python printing out the Testing from... as a binary string, which would not be the intended effect, though if need be I can remove this from the patch.
