### PR TITLE
Fixing issue with not being able to get server list.

### DIFF
--- a/speedtest_cli.py
+++ b/speedtest_cli.py
@@ -417,10 +417,10 @@ def closestServers(client, all=False):
     """
 
     urls = [
-        '://www.speedtest.net/speedtest-servers-static.php',
-        '://c.speedtest.net/speedtest-servers-static.php',
-        '://www.speedtest.net/speedtest-servers.php',
-        '://c.speedtest.net/speedtest-servers.php',
+        '://www.speedtest.net/speedtest-servers-static.php?threads=1',
+        '://c.speedtest.net/speedtest-servers-static.php?threads=1',
+        '://www.speedtest.net/speedtest-servers.php?threads=1',
+        '://c.speedtest.net/speedtest-servers.php?threads=1',
     ]
     errors = []
     servers = {}


### PR DESCRIPTION
This fixes the issue with not being able to get server list by adding '?threads=1' to the links.

I have tested it in Ubuntu 14.04 with an Orange Pi.

![screen shot 2016-08-21 at 5 55 04 am](https://cloud.githubusercontent.com/assets/6334069/17836537/db9f5cfc-6763-11e6-85fc-706011419b65.png)
