### PR TITLE
Fix for server names with foreign characters.

### DIFF
--- a/speedtest_cli.py
+++ b/speedtest_cli.py
@@ -143,7 +143,7 @@ except ImportError:
         for i, arg in enumerate(args):
             if i:
                 write(sep)
-            write(arg)
+            write(arg.encode('utf-8'))
         write(end)
 else:
     print_ = getattr(builtins, 'print')


### PR DESCRIPTION
If the auto selected server for you region has special characters in it name, the script will give an error.