### PR TITLE
Fixed "Failed to parse speedtest.net configuration" due to unsupported Accept-Encoding

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,8 +25,8 @@ env:
  - TOXENV=flake8
 
 install:
- - if [[ $(echo "$TOXENV" | egrep -c "(py2[45]|py31)") != 0 ]]; then pip install virtualenv==1.7.2 tox==1.3; fi;
- - if [[ $(echo "$TOXENV" | egrep -c "(py2[45]|py31)") == 0 ]]; then pip install tox; fi;
+ - if [[ $(echo "$TOXENV" | egrep -c "(py2[45]|py31)") != 0 ]]; then pip install virtualenv==1.7.2 tox==1.3 requests; fi;
+ - if [[ $(echo "$TOXENV" | egrep -c "(py2[45]|py31)") == 0 ]]; then pip install tox requests; fi;
 
 script:
  - tox

--- a/speedtest_cli.py
+++ b/speedtest_cli.py
@@ -19,8 +19,6 @@ import os
 import re
 import sys
 import math
-import gzip
-from StringIO import StringIO
 import signal
 import socket
 import requests
@@ -203,7 +201,7 @@ def build_user_agent():
         'speedtest-cli/%s' % __version__
     )
     user_agent = ' '.join(ua_tuple)
-    return 'User-Agent: Mozilla/5.0 (Windows NT 10.0; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/52.0.2743.116 Safari/537.36'
+    return user_agent
 
 
 def build_request(url, data=None, headers={}):
@@ -379,12 +377,13 @@ def getConfig():
     """
 
     uh = requests.get('http://www.speedtest.net/speedtest-config.php', headers = {'user-agent':user_agent})
-    configxml = []
-    configxml.append(uh.text)
-    uh.close()
+    configxml = uh.text
+    
+    if(int(uh.status_code) != 200):
+        return None
+
     try:
         try:
-            #print_(configxml)
             root = ET.fromstring(''.encode().join(configxml))
             config = {
                 'client': root.find('client').attrib,


### PR DESCRIPTION
The request to speedtest-config.php was issued with 'Accept-Encoding: Identity', in this case the server returned an empty response. Only after changing to 'Accept-Encoding: gzip' I was able to get the response from the server. I used the 'requests' library as its much easier to use with compression.