### PR TITLE
Removed b'{ text here }' from "Hosted by..." output

### DIFF
--- a/speedtest_cli.py
+++ b/speedtest_cli.py
@@ -703,8 +703,8 @@ def speedtest():
         best = getBestServer(servers)
 
     if not args.simple:
-        print_(('Hosted by %(sponsor)s (%(name)s) [%(d)0.2f km]: '
-               '%(latency)s ms' % best).encode('utf-8', 'ignore'))
+        print_('Hosted by %(sponsor)s (%(name)s) [%(d)0.2f km]: '
+               '%(latency)s ms' % best)
     else:
         print_('Ping: %(latency)s ms' % best)
 


### PR DESCRIPTION
This happend to me under Python 3.x.