### PR TITLE
Fix 2 server URLs and add notes for all 4

### DIFF
--- a/speedtest_cli.py
+++ b/speedtest_cli.py
@@ -417,10 +417,18 @@ def closestServers(client, all=False):
     """
 
     urls = [
-        '://www.speedtest.net/speedtest-servers-static.php',
-        '://c.speedtest.net/speedtest-servers-static.php',
+        # '://www.speedtest.net/speedtest-servers-static.php',
+        '://www.speedtest.net/speedtest-servers-static.php?load=1',
+            """Empty server response unless using '?load=1' or loading over https"""
+        'http://c.speedtest.net/speedtest-servers-static.php',
+            """Invalid certificate when loaded over https"""
         '://www.speedtest.net/speedtest-servers.php',
-        '://c.speedtest.net/speedtest-servers.php',
+            """Redirects to 'http://c.speedtest.net/speedtest-servers-static.php?load=1' when loaded over http
+               Doesn't show 'url2' when loaded over https"""
+        # '://c.speedtest.net/speedtest-servers.php',
+        'http://c.speedtest.net/speedtest-servers.php',
+            """Redirects to 'http://c.speedtest.net/speedtest-servers-static.php?load=1' when loaded over http
+               Invalid certificate when loaded over https"""
     ]
     errors = []
     servers = {}


### PR DESCRIPTION
Received error `Failed to retrieve list of speedtest.net servers:` every time when trying to run a speed test. Over the course of investigating the issue, I fixed the first server-list URL, and corrected a potential issue with the third one as well. I noted my findings for each of the four URLs.