### PR TITLE
Ignore broken pipes

### DIFF
--- a/speedtest_cli.py
+++ b/speedtest_cli.py
@@ -541,6 +541,16 @@ def ctrl_c(signum, frame):
     raise SystemExit('\nCancelling...')
 
 
+def sig_pipe(signum, frame):
+    """Ignore the PIPE signal when trying to output on a closed file handle,
+    and simply exit
+
+    """
+    global shutdown_event
+    shutdown_event.set()
+    raise SystemExit
+
+
 def version():
     """Print the version"""
 
@@ -554,6 +564,7 @@ def speedtest():
     shutdown_event = threading.Event()
 
     signal.signal(signal.SIGINT, ctrl_c)
+    signal.signal(signal.SIGPIPE, sig_pipe)
 
     description = (
         'Command line interface for testing internet bandwidth using '


### PR DESCRIPTION
Ignore broken pipes to allow pipping to other programs (less, head, …)
without python raising an exception when output is cut short

For example:
```
% speedtest-cli --list | head -n 5
Retrieving speedtest.net configuration...
Retrieving speedtest.net server list...
5559) Orange (Paris, France) [5.15 km]
3681) FreeMobile (Paris, France) [5.15 km]
6027) fdcservers.net (Paris, France) [5.15 km]
Traceback (most recent call last):
  File "/usr/local/bin/speedtest-cli", line 796, in <module>
    main()
  File "/usr/local/bin/speedtest-cli", line 790, in main
    speedtest()
  File "/usr/local/bin/speedtest-cli", line 638, in speedtest
    print_('\n'.join(serverList).encode('utf-8', 'ignore'))
  File "/usr/local/bin/speedtest-cli", line 146, in print_
    write(arg)
  File "/usr/local/bin/speedtest-cli", line 111, in write
    fp.write(data)
IOError: [Errno 32] Broken pipe
```