### PR TITLE
Implement country filter with --country option

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -92,6 +92,7 @@ Usage
       --list             Display a list of speedtest.net servers sorted by
                          distance
       --server SERVER    Specify a server ID to test against
+      --country COUNTRY  Select the best server matching country name
       --mini MINI        URL of the Speedtest Mini server
       --source SOURCE    Source IP address to bind to
       --timeout TIMEOUT  HTTP timeout in seconds. Default 10

--- a/speedtest_cli.py
+++ b/speedtest_cli.py
@@ -583,6 +583,8 @@ def speedtest():
                         help='Display a list of speedtest.net servers '
                              'sorted by distance')
     parser.add_argument('--server', help='Specify a server ID to test against')
+    parser.add_argument('--country', type=str.lower,
+                        help='Select the best server matching country name')
     parser.add_argument('--mini', help='URL of the Speedtest Mini server')
     parser.add_argument('--source', help='Source IP address to bind to')
     parser.add_argument('--timeout', default=10, type=int,
@@ -627,7 +629,7 @@ def speedtest():
 
     if not args.simple:
         print_('Retrieving speedtest.net server list...')
-    if args.list or args.server:
+    if args.list or args.server or args.country:
         servers = closestServers(config['client'], True)
         if args.list:
             serverList = []
@@ -649,6 +651,16 @@ def speedtest():
                                         servers))
         except IndexError:
             print_('Invalid server ID')
+            sys.exit(1)
+    elif args.country:
+        try:
+            if not args.simple:
+                print_('Selecting best server in %s based on latency...' %
+                       args.country.capitalize())
+            best = getBestServer(filter(lambda x: x['country'].lower() ==
+                                        args.country, servers))
+        except IndexError:
+            print_('No server available for this country')
             sys.exit(1)
     elif args.mini:
         name, ext = os.path.splitext(args.mini)


### PR DESCRIPTION
Implement case insensitive country filter with --country option and update README accordingly.
getBestServer() function is used to determine what is the best server if multiple servers are available for this country.

Samples :

`python speedtest_cli.py --country australia`

> Retrieving speedtest.net configuration...
> Retrieving speedtest.net server list...
> Testing from xxxxxx (xxx.xx.xxx.xxx)...
> Selecting best server in Australia based on latency...
> Hosted by 'Yes' Optus (Brisbane) [xxxx km]: 142.1 ms
> Testing download speed........................................
> Download: 8.64 Mbit/s
> Testing upload speed..................................................
> Upload: 0.67 Mbit/s

`python speedtest_cli.py --country france --simple`

> Ping: 541.393 ms
> Download: 6.45 Mbit/s
> Upload: 0.26 Mbit/s
