### PR TITLE
Python function name underscores instead of camelcase

### DIFF
--- a/speedtest.py
+++ b/speedtest.py
@@ -45,7 +45,7 @@ class FakeShutdownEvent(object):
     """
 
     @staticmethod
-    def isSet():
+    def is_set():
         "Dummy method to always return false"""
         return False
 
@@ -435,7 +435,7 @@ def print_dots(current, total, start=False, end=False):
     status
     """
 
-    if SHUTDOWN_EVENT.isSet():
+    if SHUTDOWN_EVENT.is_set():
         return
 
     sys.stdout.write('.')
@@ -463,7 +463,7 @@ class HTTPDownloader(threading.Thread):
         try:
             if (timeit.default_timer() - self.starttime) <= self.timeout:
                 f = urlopen(self.request)
-                while (not SHUTDOWN_EVENT.isSet() and
+                while (not SHUTDOWN_EVENT.is_set() and
                         (timeit.default_timer() - self.starttime) <=
                         self.timeout):
                     self.result.append(len(f.read(10240)))
@@ -506,7 +506,7 @@ class HTTPUploaderData(object):
 
     def read(self, n=10240):
         if ((timeit.default_timer() - self.start) <= self.timeout and
-                not SHUTDOWN_EVENT.isSet()):
+                not SHUTDOWN_EVENT.is_set()):
             chunk = self.data.read(n)
             self.total.append(len(chunk))
             return chunk
@@ -533,7 +533,7 @@ class HTTPUploader(threading.Thread):
         request = self.request
         try:
             if ((timeit.default_timer() - self.starttime) <= self.timeout and
-                    not SHUTDOWN_EVENT.isSet()):
+                    not SHUTDOWN_EVENT.is_set()):
                 try:
                     f = urlopen(request)
                 except TypeError:


### PR DESCRIPTION
Using [python guidelines](https://www.python.org/dev/peps/pep-0008/#function-names)