### PR TITLE
Fix except blocks using HTTP_ERRORS

### DIFF
--- a/speedtest.py
+++ b/speedtest.py
@@ -1395,14 +1395,14 @@ def shell():
     printer('Retrieving speedtest.net configuration...', quiet)
     try:
         speedtest = Speedtest()
-    except (ConfigRetrievalError, HTTP_ERRORS):
+    except ((ConfigRetrievalError,) + HTTP_ERRORS):
         printer('Cannot retrieve speedtest configuration')
         raise SpeedtestCLIError(get_exception())
 
     if args.list:
         try:
             speedtest.get_servers()
-        except (ServersRetrievalError, HTTP_ERRORS):
+        except ((ServersRetrievalError,) + HTTP_ERRORS):
             print_('Cannot retrieve speedtest server list')
             raise SpeedtestCLIError(get_exception())
 
@@ -1432,7 +1432,7 @@ def shell():
             speedtest.get_servers(servers)
         except NoMatchedServers:
             raise SpeedtestCLIError('No matched servers: %s' % args.server)
-        except (ServersRetrievalError, HTTP_ERRORS):
+        except ((ServersRetrievalError,) + HTTP_ERRORS):
             print_('Cannot retrieve speedtest server list')
             raise SpeedtestCLIError(get_exception())
         except InvalidServerIDType:


### PR DESCRIPTION
The except blocks involving HTTP_ERRORS joined the exception types in a
way that the types listed in HTTP_ERRORS appeared as a tuple, e.g.
(ServersRetrievalError, (HTTPError, …))

On a bad connection I tripped about this:
```
% speedtest-cli --share
Retrieving speedtest.net configuration...
Traceback (most recent call last):
  File "/usr/lib/python3.6/site-packages/speedtest.py", line 1346, in shell
    speedtest = Speedtest()
  File "/usr/lib/python3.6/site-packages/speedtest.py", line 704, in __init__
    self.get_config()
  File "/usr/lib/python3.6/site-packages/speedtest.py", line 726, in get_config
    raise ConfigRetrievalError(e)
speedtest.ConfigRetrievalError: timed out

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/usr/bin/speedtest-cli", line 11, in <module>
    load_entry_point('speedtest-cli==1.0.3', 'console_scripts', 'speedtest-cli')()
  File "/usr/lib/python3.6/site-packages/speedtest.py", line 1443, in main
    shell()
  File "/usr/lib/python3.6/site-packages/speedtest.py", line 1347, in shell
    except (ConfigRetrievalError, HTTP_ERRORS):
TypeError: catching classes that do not inherit from BaseException is not allowed
```

Since I wasn't able to reproduce that exact condition, I haven't been able to make sure that this 100% works yet.