### PR TITLE
Add https to share option

### DIFF
--- a/speedtest.py
+++ b/speedtest.py
@@ -1486,8 +1486,10 @@ def shell():
         print_(results.json())
 
     if args.share and not machine_format:
-        printer('Share results: %s' % results.share())
-
+        if args.secure:
+            printer('Share results: %s' % results.share().replace("http","https"))
+        else:
+            printer('Share results: %s' % results.share())
 
 def main():
     try:


### PR DESCRIPTION
If both --secure and --share option are given, the return link of the url image to share will be https, not http.