### PR TITLE
Fix mini/legacy-http-server support

### DIFF
--- a/speedtest.py
+++ b/speedtest.py
@@ -973,7 +973,7 @@ class Speedtest(object):
         if not extension:
             for ext in ['php', 'asp', 'aspx', 'jsp']:
                 try:
-                    f = urlopen('%s/speedtest/upload.%s' % (url, ext))
+                    f = urlopen('%s/upload.%s' % (url, ext))
                 except:
                     pass
                 else:
@@ -991,7 +991,7 @@ class Speedtest(object):
             'sponsor': 'Speedtest Mini',
             'name': urlparts[1],
             'd': 0,
-            'url': '%s/speedtest/upload.%s' % (url.rstrip('/'), extension[0]),
+            'url': '%s/upload.%s' % (url.rstrip('/'), extension[0]),
             'latency': 0,
             'id': 0
         }]


### PR DESCRIPTION
provided `--mini example.domain.com/speedtest/upload.php` as arguments, the script tried to find the file at `example.domain.com/speedtest/speedtest/upload.php` and failed. Fixed.

The mini/legacy server files were downloaded from https://support.ookla.com/hc/en-us/articles/234578548-Installing-HTTP-Legacy-Fallback