### PR TITLE
Automatically resolve .best property

### DIFF
--- a/speedtest.py
+++ b/speedtest.py
@@ -341,10 +341,6 @@ class SpeedtestBestServerFailure(SpeedtestException):
     """Unable to determine best server"""
 
 
-class SpeedtestMissingBestServer(SpeedtestException):
-    """get_best_server not called or not able to determine best server"""
-
-
 def create_connection(address, timeout=_GLOBAL_DEFAULT_TIMEOUT,
                       source_address=None):
     """Connect to *address* and return the socket object.
@@ -1041,10 +1037,7 @@ class Speedtest(object):
     @property
     def best(self):
         if not self._best:
-            raise SpeedtestMissingBestServer(
-                'get_best_server not called or not able to determine best '
-                'server'
-            )
+            self.get_best_server()
         return self._best
 
     def get_config(self):

--- a/speedtest.py
+++ b/speedtest.py
@@ -341,6 +341,10 @@ class SpeedtestBestServerFailure(SpeedtestException):
     """Unable to determine best server"""
 
 
+class SpeedtestMissingBestServer(SpeedtestException):
+    """get_best_server not called or not able to determine best server"""
+
+
 def create_connection(address, timeout=_GLOBAL_DEFAULT_TIMEOUT,
                       source_address=None):
     """Connect to *address* and return the socket object.


### PR DESCRIPTION
hello 👋 !

This removes the exception `SpeedtestMissingBestServer`, and makes the `.best` property automatically call `.get_best_server()`.

This changes a download test to:
```python
import speedtest
tester = speedtest.Speedtest()
# tester.get_best_server()  # No longer needed
tester.download()
```

I think this is sensible as I can't see a time that when accessing `.best`, the desired outcome wouldn't be to just get the best server. If the exception is encountered, the only step for a user to take is to do a `.get_best_server()`, so might as well do that automatically.