### PR TITLE
Fix python3 upload problem

### DIFF
--- a/speedtest.py
+++ b/speedtest.py
@@ -1525,9 +1525,11 @@ class Speedtest(object):
             )
             if pre_allocate:
                 data.pre_allocate()
+            # Fix python3 upload problem: Add Content-length to avoid AbstractHTTPHandler use chunked
+            headers = {'Content-length': size}
             requests.append(
                 (
-                    build_request(self.best['url'], data, secure=self._secure),
+                    build_request(self.best['url'], data, secure=self._secure, headers=headers),
                     size
                 )
             )


### PR DESCRIPTION
In python3, if Content-length is not set,urllib.request.AbstractHTTPHandler::do_request_() will use "Transfer-encoding:chunked", which will cause HTTPUploader not to exit until timeout