### PR TITLE
Provide test server's FQDN:PORT

### DIFF
--- a/speedtest.py
+++ b/speedtest.py
@@ -36,7 +36,7 @@ except ImportError:
     gzip = None
     GZIP_BASE = object
 
-__version__ = '2.1.2'
+__version__ = '2.1.2.reveal-server'
 
 
 class FakeShutdownEvent(object):
@@ -1039,7 +1039,7 @@ class SpeedtestResults(object):
         """Return CSV Headers"""
 
         row = ['Server ID', 'Sponsor', 'Server Name', 'Timestamp', 'Distance',
-               'Ping', 'Download', 'Upload', 'Share', 'IP Address']
+               'Ping', 'Download', 'Upload', 'Share', 'Client', 'Server']
         out = StringIO()
         writer = csv.writer(out, delimiter=delimiter, lineterminator='')
         writer.writerow([to_utf8(v) for v in row])
@@ -1054,7 +1054,8 @@ class SpeedtestResults(object):
         row = [data['server']['id'], data['server']['sponsor'],
                data['server']['name'], data['timestamp'],
                data['server']['d'], data['ping'], data['download'],
-               data['upload'], self._share or '', self.client['ip']]
+               data['upload'], self._share or '', self.client['ip'],
+               data['server']['host']]
         writer.writerow([to_utf8(v) for v in row])
         return out.getvalue()
 
@@ -1928,7 +1929,7 @@ def shell():
 
     results = speedtest.results
 
-    printer('Hosted by %(sponsor)s (%(name)s) [%(d)0.2f km]: '
+    printer('Hosted by %(sponsor)s (%(name)s) %(host)s [%(d)0.2f km]: '
             '%(latency)s ms' % results.server, quiet)
 
     if args.download:


### PR DESCRIPTION
Provide the test server's FQDN:PORT
```
$ ./speedtest.py --list | head -3
Retrieving speedtest.net configuration...
 2407) Spectrum (Medford, OR, United States) [2.62 km]
10964) Hunter Communications (Central Point, OR, United States) [6.97 km]
$ ./speedtest.py --server 10964
Retrieving speedtest.net configuration...
Testing from Spectrum (A.B.C.D)...
Retrieving speedtest.net server list...
Retrieving information for the selected server...
Hosted by Hunter Communications (Central Point, OR) speedtest.huntercom.net:8080 [6.97 km]: 36.404 ms
Testing download speed................................................................................
Download: 109.10 Mbit/s
Testing upload speed................................................................................................
Upload: 6.90 Mbit/s
$ 
```
to facilitate further network investigation by other tools (e.g. [mtr](https://www.bitwizard.nl/mtr/))
```
$ sudo mtr -wrbzc 10 -o "LS NABWV JMXI" -TP 8080 speedtest.huntercom.net
Start: 2019-10-02T14:59:24-0700
HOST: Bobs-MacBook-Pro.local                                                                      Loss%   Snt   Last   Avg  Best  Wrst StDev  Jttr Javg Jmax Jint
  1. AS???    gw (192.168.1.1)                                                                     0.0%    10    0.8   0.7   0.5   0.8   0.1   0.0  0.1  0.2  0.8
  2. AS???    ???                                                                                 100.0    10    0.0   0.0   0.0   0.0   0.0   0.0  0.0  0.0  0.0
  3. AS???    96-34-109-113.static.unas.or.charter.com (96.34.109.113)                             0.0%    10   15.5   9.8   7.9  15.5   2.7   6.3  1.9  6.3 15.2
  4. AS???    96-34-111-202.static.unas.or.charter.com (96.34.111.202)                             0.0%    10    9.2   9.3   7.6  13.8   1.7   0.9  1.6  5.5 12.5
  5. AS???    96-34-108-160.static.unas.or.charter.com (96.34.108.160)                             0.0%    10   10.9  13.7   9.2  20.5   3.2   4.3  3.0  9.3 22.6
  6. AS???    bbr02sttlwa-bue-4.sttl.wa.charter.com (96.34.0.56)                                   0.0%    10   18.0  22.0  18.0  25.5   2.5   6.4  2.7  6.4 21.5
  7. AS???    prr01sttlwa-bue-2.sttl.wa.charter.com (96.34.3.39)                                   0.0%    10   17.5  16.9  16.4  17.5   0.4   0.5  0.4  0.8  3.0
  8. AS6939   10ge2-1.core1.sea1.he.net (66.160.133.117)                                           0.0%    10   17.7  17.0  16.4  18.1   0.6   0.7  0.5  1.6  4.1
  9. AS6939   100ge15-1.core1.pdx1.he.net (184.105.64.138)                                         0.0%    10   20.3  21.1  19.8  26.1   2.1   0.0  1.6  5.9 11.1
 10. AS6939   hunter-communications-inc.10gigabitethernet1-1-1.switch3.pdx1.he.net (65.49.8.20     0.0%    10   20.3  23.4  19.7  45.9   8.0   0.5  5.8 25.7 38.5
 11. AS???    ???                                                                                 100.0    10    0.0   0.0   0.0   0.0   0.0   0.0  0.0  0.0  0.0
 12. AS36012  speedtest.huntercom.net (216.115.0.18)                                               0.0%    10   32.6  29.0  27.0  34.4   2.4   1.8  1.2  6.9 10.8
$ 
```
Also clarify the CIDR is mine (label `Client`) in CSV header
```
$ ./speedtest.py --csv-header --share
Server ID,Sponsor,Server Name,Timestamp,Distance,Ping,Download,Upload,Share,Client,Server
$ ./speedtest.py --server 10964 --share --csv
10964,Hunter Communications,"Central Point, OR",2019-10-02T22:12:53.579771Z,6.972356894049519,33.068,109320494.9007473,10692201.635022497,http://www.speedtest.net/result/8642498019.png,96.39.167.165,speedtest.huntercom.net:8080
$ 
```