### PR TITLE
Add run on repl.it badge to README

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,0 +1,2 @@
+language = "python3"
+run = "python setup.py install ; speedtest -h"

--- a/README.rst
+++ b/README.rst
@@ -13,6 +13,9 @@ speedtest.net
 .. image:: https://img.shields.io/pypi/l/speedtest-cli.svg
         :target: https://pypi.python.org/pypi/speedtest-cli/
         :alt: License
+.. image:: https://repl.it/badge/github/sivel/speedtest-cli
+    :target: https://repl.it/github/sivel/speedtest-cli
+    :alt: Repl.it
 
 Versions
 --------


### PR DESCRIPTION
This pull request configures this repository to be run on Repl.it.      It adds a `.replit` configuration file and a Repl.it badge to the `README`.
     You can read more about running repos on Repl.it [here](https://docs.repl.it/repls/dot-replit), or view the Repl [here](https://repl.it/@Mosrod/speedtest-cli).