### PR TITLE
Fixing server list to respect exclude flag

### DIFF
--- a/speedtest.py
+++ b/speedtest.py
@@ -1880,7 +1880,10 @@ def shell():
 
     if args.list:
         try:
-            speedtest.get_servers()
+            if args.exclude:
+              speedtest.get_servers(exclude=args.exclude)
+            else:
+              speedtest.get_servers()
         except (ServersRetrievalError,) + HTTP_ERRORS:
             printer('Cannot retrieve speedtest server list', error=True)
             raise SpeedtestCLIError(get_exception())


### PR DESCRIPTION
Here is a patch to make `--list` respect `--exclude`.  I had to exclude a bad server from the server list tonight and found this wasn't functioning as expected.