### PR TITLE
Test against static servers

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -75,12 +75,13 @@ Usage
 ::
 
     $ speedtest-cli -h
-    usage: speedtest-cli [-h] [--no-download] [--no-upload] [--single] [--bytes]
-                         [--share] [--simple] [--csv]
-                         [--csv-delimiter CSV_DELIMITER] [--csv-header] [--json]
-                         [--list] [--server SERVER] [--exclude EXCLUDE]
-                         [--mini MINI] [--source SOURCE] [--timeout TIMEOUT]
-                         [--secure] [--no-pre-allocate] [--version]
+    usage: speedtest.py [-h] [--no-download] [--no-upload] [--single] [--bytes]
+                        [--share] [--simple] [--csv]
+                        [--csv-delimiter CSV_DELIMITER] [--csv-header] [--json]
+                        [--load-servers-from-json SERVERS_JSON] [--list]
+                        [--server SERVER] [--exclude EXCLUDE] [--mini MINI]
+                        [--source SOURCE] [--timeout TIMEOUT] [--secure]
+                        [--no-pre-allocate] [--version]
 
     Command line interface for testing internet bandwidth using speedtest.net.
     --------------------------------------------------------------------------
@@ -108,10 +109,12 @@ Usage
       --json                Suppress verbose output, only show basic information
                             in JSON format. Speeds listed in bit/s and not
                             affected by --bytes
+      --load-servers-from-json SERVERS_JSON
+                            Load servers from json file for static testing
       --list                Display a list of speedtest.net servers sorted by
                             distance
-      --server SERVER       Specify a server ID to test against. Can be supplied
-                            multiple times
+      --server SERVER       Specify a server ID from --list servers to test
+                            against. Can be supplied multiple times
       --exclude EXCLUDE     Exclude a server from selection. Can be supplied
                             multiple times
       --mini MINI           URL of the Speedtest Mini server
@@ -124,6 +127,7 @@ Usage
                             support systems with insufficient memory, use this
                             option to avoid a MemoryError
       --version             Show the version number and exit
+
 
 
 Python API

--- a/example-server.json
+++ b/example-server.json
@@ -1,0 +1,16 @@
+{
+    "313.8447559412203": [
+        {
+            "url": "http://speedtest.glasfaser-ostbayern.de:8080/speedtest/upload.php",
+            "lat": "49.0167",
+            "lon": "12.0833",
+            "name": "Regensburg",
+            "country": "Germany",
+            "cc": "DE",
+            "sponsor": "R-KOM GmbH & Co. KG",
+            "id": "4404",
+            "host": "speedtest.glasfaser-ostbayern.de:8080",
+            "d": 313.8447559412203
+        }
+    ]
+}

--- a/speedtest.py
+++ b/speedtest.py
@@ -1753,12 +1753,12 @@ def parse_args():
                              'information in JSON format. Speeds listed in '
                              'bit/s and not affected by --bytes')
     parser.add_argument('--load-servers-from-json', dest='servers_json', type=PARSER_TYPE_STR,
-                        help='Serverlist for static testing in json Format')
+                        help='Load servers from json file for static testing')
     parser.add_argument('--list', action='store_true',
                         help='Display a list of speedtest.net servers '
                              'sorted by distance')
     parser.add_argument('--server', type=PARSER_TYPE_INT, action='append',
-                        help='Specify a server ID to test against. Can be '
+                        help='Specify a server ID from --list servers to test against. Can be '
                              'supplied multiple times')
     parser.add_argument('--exclude', type=PARSER_TYPE_INT, action='append',
                         help='Exclude a server from selection. Can be '


### PR DESCRIPTION
I've added a option to test against a list of servers loaded from a json file.

I needed this option because the server I wanted to test against sometimes didn't appeared in `speedtest.get_servers()`

Now we can define one ore more servers like this:
`example-server.json`
```
{
    "313.8447559412203": [
        {
            "url": "http://speedtest.glasfaser-ostbayern.de:8080/speedtest/upload.php",
            "lat": "49.0167",
            "lon": "12.0833",
            "name": "Regensburg",
            "country": "Germany",
            "cc": "DE",
            "sponsor": "R-KOM GmbH & Co. KG",
            "id": "4404",
            "host": "speedtest.glasfaser-ostbayern.de:8080",
            "d": 313.8447559412203
        }
    ]
}
```

