### PR TITLE
Reorder speedtest servers URLs, preferring c.speedtest.net domain

### DIFF
--- a/speedtest.py
+++ b/speedtest.py
@@ -1246,10 +1246,10 @@ class Speedtest(object):
                     )
 
         urls = [
-            '://www.speedtest.net/speedtest-servers-static.php',
             'http://c.speedtest.net/speedtest-servers-static.php',
-            '://www.speedtest.net/speedtest-servers.php',
             'http://c.speedtest.net/speedtest-servers.php',
+            '://www.speedtest.net/speedtest-servers-static.php',
+            '://www.speedtest.net/speedtest-servers.php',
         ]
 
         headers = {}


### PR DESCRIPTION
There's a subtle difference in behavior between the c.speedtest.net and www.speedtest.net domains, with c.speedtest.net yielding a server list that is more relevant to the actual location that it is run from.  This PR just reorders the four URLs that are used to fetch the server list, bumping the c.speedtest.net URLs to the top.

Both domains return 100 servers in the results, but if run from Perth, Australia, c.speedtest.net returns 100 servers centered around Perth (with 14 actually in Perth) and www.speedtest.net returns 100 servers centered around Sydney, with the nearest server over 1300 miles away.  I have seen similar results in the US, as well.