### PR TITLE
ValueError: invalid literal for int() with base 10: ''

### DIFF
--- a/speedtest.py
+++ b/speedtest.py
@@ -1170,9 +1170,11 @@ class Speedtest(object):
             # times = get_attributes_by_tag_name(root, 'times')
             client = get_attributes_by_tag_name(root, 'client')
 
-        ignore_servers = list(
-            map(int, server_config['ignoreids'].split(','))
-        )
+        if server_config['ignoreids'] == "":
+            ignore_servers = list()
+        else:
+            ignore_servers = list(map(int, server_config['ignoreids'].split(',')))
+
 
         ratio = int(upload['ratio'])
         upload_max = int(upload['maxchunkcount'])


### PR DESCRIPTION
When creating a new instance of Speedtest I get the following exception because ignoreids is just an empty string in the speedtest-config fetched from www.speedtest.net/speedtest-config.php:

`<server-config threadcount="4" ignoreids="" notonmap="" forcepingid="" preferredserverid=""/>`

```
s = speedtest.Speedtest()
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/tzwickl/.local/lib/python3.7/site-packages/speedtest.py", line 1091, in __init__
    self.get_config()
  File "/home/tzwickl/.local/lib/python3.7/site-packages/speedtest.py", line 1174, in get_config
    map(int, server_config['ignoreids'].split(','))
ValueError: invalid literal for int() with base 10: ''
```