### PR TITLE
ValueError: invalid literal for int() with base 10: ''

### DIFF
--- a/speedtest.py
+++ b/speedtest.py
@@ -1171,7 +1171,7 @@ class Speedtest(object):
             client = get_attributes_by_tag_name(root, 'client')
 
         ignore_servers = list(
-            map(int, server_config['ignoreids'].split(','))
+            map(int, (server_config['ignoreids'].split(',') if len(server_config['ignoreids']) else []) )
         )
 
         ratio = int(upload['ratio'])


### PR DESCRIPTION
This PR is a fix to `ValueError: invalid literal for int() with base 10: ''`