### PR TITLE
TypeError fix for unexpected NoneType in summation of list

### DIFF
--- a/speedtest.py
+++ b/speedtest.py
@@ -1656,7 +1656,8 @@ class Speedtest(object):
                 while _is_alive(thread):
                     thread.join(timeout=0.001)
                 in_flight['threads'] -= 1
-                finished.append(thread.result)
+                if type(thread.result) in (int, float):
+                    finished.append(thread.result)
                 callback(thread.i, request_count, end=True)
 
         q = Queue(threads or self.config['threads']['upload'])


### PR DESCRIPTION
```
Traceback (most recent call last):
  File "/usr/bin/speedtest", line 11, in <module>
    load_entry_point('speedtest-cli==2.0.2', 'console_scripts', 'speedtest')()
  File "/usr/lib/python3/dist-packages/speedtest.py", line 1887, in main
    shell()
  File "/usr/lib/python3/dist-packages/speedtest.py", line 1856, in shell
    speedtest.upload(callback=callback, pre_allocate=args.pre_allocate)
  File "/usr/lib/python3/dist-packages/speedtest.py", line 1577, in upload
    self.results.bytes_sent = sum(finished)
TypeError: unsupported operand type(s) for +: 'int' and 'NoneType'
```
Caused when the "finished" list is summed with the function "sum" near line 1678.
