### PR TITLE
Use identical download sizes for HTTP- and socket-based download tests

### DIFF
--- a/speedtest.py
+++ b/speedtest.py
@@ -1219,13 +1219,9 @@ class Speedtest(object):
         sizes = {
             'upload': up_sizes[ratio - 1:],
         }
-        if self._use_socket:
-            sizes['download'] = [245388, 505544, 1118012, 1986284, 4468241,
-                                 7907740, 12407926, 17816816, 24262167,
-                                 31625365]
-        else:
-            sizes['download'] = [350, 500, 750, 1000, 1500, 2000, 2500,
-                                 3000, 3500, 4000]
+        sizes['download'] = [245388, 505544, 1118012, 1986284, 4468241,
+                             7907740, 12407926, 17816816, 24262167,
+                             31625365]
 
         size_count = len(sizes['upload'])
 
@@ -1703,8 +1699,8 @@ class Speedtest(object):
             for size in self.config['sizes']['download']:
                 for _ in range(0, self.config['counts']['download']):
                     urls.append(
-                        '%s/random%sx%s.jpg' %
-                        (os.path.dirname(self.best['url']), size, size)
+                        '%s/download?size=%d' %
+                        (os.path.dirname(os.path.dirname(self.best['url'])), size)
                     )
 
             request_count = len(urls)

--- a/speedtest.py
+++ b/speedtest.py
@@ -1376,28 +1376,25 @@ class Speedtest(object):
 
                 for attrib in attriblist:
                     if servers and int(attrib.get('id')) not in servers:
+                        # Not one of the preselected servers
                         continue
 
                     if (int(attrib.get('id')) in self.config['ignore_servers']
                             or int(attrib.get('id')) in exclude):
+                        # One of the specifically excluded or ignored servers
                         continue
 
                     host, port = attrib['host'].split(':')
                     attrib['host'] = (host, int(port))
 
                     try:
-                        d = distance(self.lat_lon,
-                                     (float(attrib.get('lat')),
-                                      float(attrib.get('lon'))))
+                        d = attrib['d'] = distance(self.lat_lon,
+                                                   (float(attrib.get('lat')),
+                                                    float(attrib.get('lon'))))
                     except Exception:
                         continue
 
-                    attrib['d'] = d
-
-                    try:
-                        self.servers[d].append(attrib)
-                    except KeyError:
-                        self.servers[d] = [attrib]
+                    self.servers.setdefault(d, []).append(attrib)
 
                 break
 


### PR DESCRIPTION
This requires switching the HTTP download test from the `/speedtest/randomNxN.jpg` endpoint to the `/download?size=N` endpoint, as used by the web interface of Speedtest.net currently.