### PR TITLE
Add option --custom to perform test with custom servers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,6 @@ pip-log.txt
 
 #Mr Developer
 .mr.developer.cfg
+
+#Environment
+speedtest-env

--- a/setup.py
+++ b/setup.py
@@ -92,5 +92,8 @@ setup(
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: 3.9',
+        'Programming Language :: Python :: 3.10',
     ]
 )

--- a/speedtest.py
+++ b/speedtest.py
@@ -15,18 +15,18 @@
 #    License for the specific language governing permissions and limitations
 #    under the License.
 
-import os
-import re
 import csv
-import sys
-import math
+import datetime
 import errno
+import math
+import os
+import platform
+import re
 import signal
 import socket
-import timeit
-import datetime
-import platform
+import sys
 import threading
+import timeit
 import xml.parsers.expat
 
 try:
@@ -36,7 +36,7 @@ except ImportError:
     gzip = None
     GZIP_BASE = object
 
-__version__ = '2.1.3'
+__version__ = '2.1.4b1'
 
 
 class FakeShutdownEvent(object):
@@ -49,6 +49,8 @@ class FakeShutdownEvent(object):
         "Dummy method to always return false"""
         return False
 
+    is_set = isSet
+
 
 # Some global variables we use
 DEBUG = False
@@ -56,6 +58,7 @@ _GLOBAL_DEFAULT_TIMEOUT = object()
 PY25PLUS = sys.version_info[:2] >= (2, 5)
 PY26PLUS = sys.version_info[:2] >= (2, 6)
 PY32PLUS = sys.version_info[:2] >= (3, 2)
+PY310PLUS = sys.version_info[:2] >= (3, 10)
 
 # Begin import game to handle Python 2 and Python 3
 try:
@@ -266,17 +269,6 @@ else:
             write(arg)
         write(end)
 
-if PY32PLUS:
-    etree_iter = ET.Element.iter
-elif PY25PLUS:
-    etree_iter = ET_Element.getiterator
-
-if PY26PLUS:
-    thread_is_alive = threading.Thread.is_alive
-else:
-    thread_is_alive = threading.Thread.isAlive
-
-
 # Exception "constants" to support Python 2 through Python 3
 try:
     import ssl
@@ -292,6 +284,23 @@ try:
 except ImportError:
     ssl = None
     HTTP_ERRORS = (HTTPError, URLError, socket.error, BadStatusLine)
+
+if PY32PLUS:
+    etree_iter = ET.Element.iter
+elif PY25PLUS:
+    etree_iter = ET_Element.getiterator
+
+if PY26PLUS:
+    thread_is_alive = threading.Thread.is_alive
+else:
+    thread_is_alive = threading.Thread.isAlive
+
+
+def event_is_set(event):
+    try:
+        return event.is_set()
+    except AttributeError:
+        return event.isSet()
 
 
 class SpeedtestException(Exception):
@@ -769,7 +778,7 @@ def print_dots(shutdown_event):
     status
     """
     def inner(current, total, start=False, end=False):
-        if shutdown_event.isSet():
+        if event_is_set(shutdown_event):
             return
 
         sys.stdout.write('.')
@@ -808,7 +817,7 @@ class HTTPDownloader(threading.Thread):
         try:
             if (timeit.default_timer() - self.starttime) <= self.timeout:
                 f = self._opener(self.request)
-                while (not self._shutdown_event.isSet() and
+                while (not event_is_set(self._shutdown_event) and
                         (timeit.default_timer() - self.starttime) <=
                         self.timeout):
                     self.result.append(len(f.read(10240)))
@@ -864,7 +873,7 @@ class HTTPUploaderData(object):
 
     def read(self, n=10240):
         if ((timeit.default_timer() - self.start) <= self.timeout and
-                not self._shutdown_event.isSet()):
+                not event_is_set(self._shutdown_event)):
             chunk = self.data.read(n)
             self.total.append(len(chunk))
             return chunk
@@ -902,7 +911,7 @@ class HTTPUploader(threading.Thread):
         request = self.request
         try:
             if ((timeit.default_timer() - self.starttime) <= self.timeout and
-                    not self._shutdown_event.isSet()):
+                    not event_is_set(self._shutdown_event)):
                 try:
                     f = self._opener(request)
                 except TypeError:

--- a/speedtest.py
+++ b/speedtest.py
@@ -1250,7 +1250,7 @@ class Speedtest(object):
             except (KeyError,SyntaxError) as e:
                 pass
             message += "\n</servers>\n</settings>\n"
-            return message.replace("&","").encode()
+            return message.replace("&","").replace("%","").encode()
 
 
     def get_servers(self, servers=None, exclude=None, custom_server=None):
@@ -1375,7 +1375,6 @@ class Speedtest(object):
                 if int(uh.code) != 200:
                     raise ServersRetrievalError()
                 serversxml = ''.encode().join(serversxml_list)
-                print(serversxml)
                 printer('Servers XML:\n%s' % serversxml, debug=True)
 
                 try:


### PR DESCRIPTION
Hello. I added the ``--custom`` argument so that users can include a URL like ``https://www.speedtest.net/api/js/servers?engine=js&search=orange&https_functional=true&limit=1`` and perform speedtests against a server of their liking.

__Update 7/3/2022__: 

* added interoperability feature to make ``--custom`` work alongside with ``--server`` that way we can choose a specific server from custom link.

For instance, a command like ``speedtest --custom "https://www.speedtest.net/api/js/servers?engine=js&search=Comcast&https_functional=true" --server 37808`` should ping ``Comcast (Atlanta, GA)``