### PR TITLE
Remove break in `get_servers`

### DIFF
--- a/speedtest.py
+++ b/speedtest.py
@@ -1353,8 +1353,6 @@ class Speedtest(object):
                     except KeyError:
                         self.servers[d] = [attrib]
 
-                break
-
             except ServersRetrievalError:
                 continue
 


### PR DESCRIPTION
Remove the break in the `get_servers` method so that we can get the list of servers from all urls.