### PR TITLE
Added a method for converting a server dictionary to a server list

### DIFF
--- a/speedtest.py
+++ b/speedtest.py
@@ -1437,6 +1437,14 @@ class Speedtest(object):
         printer('Closest Servers:\n%r' % self.closest, debug=True)
         return self.closest
 
+    @staticmethod
+    def get_normalize_servers(dict_servers):
+        """
+        Converting a server dictionary to a server list
+        """
+
+        return [server for _, servers in dict_servers.items() for server in servers]
+
     def get_best_server(self, servers=None):
         """Perform a speedtest.net "ping" to determine which speedtest.net
         server has the lowest latency
@@ -1445,7 +1453,11 @@ class Speedtest(object):
         if not servers:
             if not self.closest:
                 servers = self.get_closest_servers()
-            servers = self.closest
+            else:
+                servers = self.closest
+
+        if type(servers) is dict:
+            servers = self.get_normalize_servers(servers)
 
         if self._source_address:
             source_address_tuple = (self._source_address, 0)


### PR DESCRIPTION
I found the following error in the code if I want to get a better server this way:

```
sp = speedtest.Speedtest()
best_servers = sp.get_servers()
sp.get_best_server(best_servers)
```

I get an error:
```
Traceback (most recent call last):
  File "/speedtest/main.py", line 18, in <module>
    test_connection()
  File "/speedtest/main.py", line 8, in test_connection
    sp.get_best_server(best_servers)
  File "\speedtest\venv\lib\site-packages\speedtest.py", line 1459, in get_best_server
    url = os.path.dirname(server['url'])
TypeError: 'float' object is not subscriptable
```
I also added the else block, otherwise the condition is incorrect on line 1456.

