### PR TITLE
403Error-Fail to get_config

### DIFF
--- a/speedtest.py
+++ b/speedtest.py
@@ -1129,6 +1129,7 @@ class Speedtest(object):
         headers = {}
         if gzip:
             headers['Accept-Encoding'] = 'gzip'
+        headers['Accept'] = 'text/html,application/xhtml+xml,application/xml'
         request = build_request('://www.speedtest.net/speedtest-config.php',
                                 headers=headers, secure=self._secure)
         uh, e = catch_request(request, opener=self._opener)


### PR DESCRIPTION
Add headers['Accept'] to prevent 403 error from speedtest server