### PR TITLE
Support binding to a client port in addition to a client address.

### DIFF
--- a/speedtest.py
+++ b/speedtest.py
@@ -1130,7 +1130,6 @@ class Speedtest(object):
         headers = {}
         if gzip:
             headers['Accept-Encoding'] = 'gzip'
-        headers['Accept'] = 'text/html,application/xhtml+xml,application/xml'
         request = build_request('://www.speedtest.net/speedtest-config.php',
                                 headers=headers, secure=self._secure)
         uh, e = catch_request(request, opener=self._opener)
@@ -1771,8 +1770,8 @@ def parse_args():
     parser.add_argument('--mini', help='URL of the Speedtest Mini server')
     parser.add_argument('--source',
                         help='Source IP address and source port to bind to.'
-                             'Use the form A.B.C.D:P. You can leave the IP'
-                             'address or port empty and eliminate the colon'
+                             'Use the form A.B.C.D:P. You can leave the IP '
+                             'address or port empty and eliminate the colon '
                              'for defaults')
     parser.add_argument('--timeout', default=10, type=PARSER_TYPE_FLOAT,
                         help='HTTP timeout in seconds. Default 10')

--- a/speedtest.py
+++ b/speedtest.py
@@ -590,7 +590,8 @@ def build_opener(source_address=None, timeout=10):
     printer('Timeout set to %d' % timeout, debug=True)
 
     if source_address:
-        source_address_tuple = (source_address, 0)
+        split_source_address = source_address.split(':')
+        source_address_tuple = (source_address, 0) if len(split_source_address) == 1 else (split_source_address[0], int(split_source_address[1])) 
         printer('Binding to source address: %r' % (source_address_tuple,),
                 debug=True)
     else:
@@ -1129,6 +1130,7 @@ class Speedtest(object):
         headers = {}
         if gzip:
             headers['Accept-Encoding'] = 'gzip'
+        headers['Accept'] = 'text/html,application/xhtml+xml,application/xml'
         request = build_request('://www.speedtest.net/speedtest-config.php',
                                 headers=headers, secure=self._secure)
         uh, e = catch_request(request, opener=self._opener)
@@ -1767,7 +1769,11 @@ def parse_args():
                         help='Exclude a server from selection. Can be '
                              'supplied multiple times')
     parser.add_argument('--mini', help='URL of the Speedtest Mini server')
-    parser.add_argument('--source', help='Source IP address to bind to')
+    parser.add_argument('--source',
+                        help='Source IP address and source port to bind to.'
+                             'Use the form A.B.C.D:P. You can leave the IP'
+                             'address or port empty and eliminate the colon'
+                             'for defaults')
     parser.add_argument('--timeout', default=10, type=PARSER_TYPE_FLOAT,
                         help='HTTP timeout in seconds. Default 10')
     parser.add_argument('--secure', action='store_true',
@@ -1993,7 +1999,7 @@ def shell():
     if args.share and not machine_format:
         printer('Share results: %s' % results.share())
 
-
+      
 def main():
     try:
         shell()


### PR DESCRIPTION
I'd like speedtest to be able to bind to a client port, in addition to an IP. I extended source_address to support IP:PORT scheme and made it so you could optionally include the port or the IP address. The reason I want to bind to a client port is that I want my firewall to be route the speedtest through different external gateways based on the client port. This allows me to run speed tests against the different egress routes on my network but run the speedtest from a device that is not my router. This should be entirely backwards compatible.