### PR TITLE
readme: note --csv-headers exits

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -104,7 +104,7 @@ Usage
       --csv-delimiter CSV_DELIMITER
                             Single character delimiter to use in CSV output.
                             Default ","
-      --csv-header          Print CSV headers
+      --csv-header          Print CSV headers and exit
       --json                Suppress verbose output, only show basic information
                             in JSON format. Speeds listed in bit/s and not
                             affected by --bytes

--- a/speedtest-cli.1
+++ b/speedtest-cli.1
@@ -65,7 +65,7 @@ Single character delimiter to use in CSV output. Default ","
 
 \fB\-\-csv\-header\fR
 .RS
-Print CSV headers
+Print CSV headers and exit
 .RE
 
 \fB\-\-json\fR


### PR DESCRIPTION
This is now in line with `--help` description. I thought that `--csv-header` would print the header AND the results when combined with `--csv`.

I didn't add myself to the page authors or update the date. Note that you didn't update the date in the first line in the previous readme change too: https://github.com/sivel/speedtest-cli/commit/3109fcf407a948f1a867da122267cfe9ece7150f I don't know if this is required.