### PR TITLE
Add an option to load the server list from the local file.

### DIFF
--- a/server-list.txt
+++ b/server-list.txt
@@ -1,0 +1,15 @@
+<?xml version="1.0"?>
+<settings>
+<servers>
+<server url="http://speedtest.deltacable.com:8080/speedtest/upload.php" lat="49.0902" lon="-123.0652" name="Delta, BC" country="Canada" cc="CA" sponsor="Eastlink" id="22154" host="speedtest.deltacable.com:8080"/>
+<server url="https://speedtest.vc.shawcable.net:8080/speedtest/upload.php" lat="49.2505" lon="-123.1119" name="Vancouver, BC" country="Canada" cc="CA" sponsor="Shaw Communications" id="4243" host="speedtest.vc.shawcable.net:8080"/>
+<server url="http://speedtest.skywaywest.net:8080/speedtest/upload.php" lat="49.2505" lon="-123.1119" name="Vancouver, BC" country="Canada" cc="CA" sponsor="Skyway West Business Internet Services" id="3318" host="speedtest.skywaywest.net:8080"/>
+<server url="http://speedtest-6.aebc.com:8080/speedtest/upload.php" lat="49.2505" lon="-123.1119" name="Vancouver, BC" country="Canada" cc="CA" sponsor="AEBC Internet" id="41509" host="speedtest-6.aebc.com:8080"/>
+<server url="http://speedtest.van3.fibretel.ca:8080/speedtest/upload.php" lat="49.2505" lon="-123.1119" name="Vancouver, BC" country="Canada" cc="CA" sponsor="FIBRETEL" id="58622" host="speedtest.van3.fibretel.ca:8080"/>
+<server url="http://fast.rockisland.net:8080/speedtest/upload.php" lat="48.5343" lon="-123.0171" name="Friday Harbor, WA" country="United States" cc="US" sponsor="Rock Island Communications" id="26805" host="fast.rockisland.net:8080"/>
+<server url="http://speedtest.cityofanacortes.org:8080/speedtest/upload.php" lat="48.5126" lon="-122.6127" name="Anacortes, WA" country="United States" cc="US" sponsor="City of Anacortes" id="31110" host="speedtest.cityofanacortes.org:8080"/>
+<server url="http://ost02.whidbey.net:8080/speedtest/upload.php" lat="48.0401" lon="-122.4063" name="Langley, WA" country="United States" cc="US" sponsor="Whidbey Telecom" id="54406" host="ost02.whidbey.net:8080"/>
+<server url="https://speedtestvm-evrtwaxa.as20055.net:8080/speedtest/upload.php" lat="47.9790" lon="-122.2021" name="Everett, WA" country="United States" cc="US" sponsor="Ziply Fiber" id="42157" host="speedtestvm-evrtwaxa.as20055.net:8080"/>
+<server url="http://speedtest1-bothwaxb.as20055.net:8080/speedtest/upload.php" lat="47.7717" lon="-122.2044" name="Bothell, WA" country="United States" cc="US" sponsor="Ziply Fiber" id="51693" host="speedtest1-bothwaxb.as20055.net:8080"/>
+</servers>
+</settings>

--- a/speedtest.py
+++ b/speedtest.py
@@ -1237,7 +1237,7 @@ class Speedtest(object):
 
         return self.config
 
-    def get_servers(self, servers=None, exclude=None):
+    def get_servers(self, servers=None, exclude=None, load_servers=None):
         """Retrieve a the list of speedtest.net servers, optionally filtered
         to servers matching those specified in the ``servers`` argument
         """
@@ -1325,6 +1325,14 @@ class Speedtest(object):
                         elements = root.getElementsByTagName('server')
                 except (SyntaxError, xml.parsers.expat.ExpatError):
                     raise ServersRetrievalError()
+
+                #load from file if exist
+                printer('Servers File:\n%s' % load_servers, debug=True)
+                if load_servers is not None:
+                    if os.path.isfile(load_servers):
+                        serverfile = ET.parse(load_servers)
+                        serverlist = serverfile.getroot()
+                        elements = elements + list(set(serverlist[0])-set(elements))
 
                 for server in elements:
                     try:
@@ -1757,6 +1765,8 @@ def parse_args():
                         help='Suppress verbose output, only show basic '
                              'information in JSON format. Speeds listed in '
                              'bit/s and not affected by --bytes')
+    parser.add_argument('--load-servers', action='append',
+                        help='Load list of servers from file')
     parser.add_argument('--list', action='store_true',
                         help='Display a list of speedtest.net servers '
                              'sorted by distance')
@@ -1891,9 +1901,18 @@ def shell():
         printer('Cannot retrieve speedtest configuration', error=True)
         raise SpeedtestCLIError(get_exception())
 
+    if args.load_servers:
+        printer('Loading file with servers...', quiet)
+        if not os.path.isfile(args.load_servers[0]):
+            raise SystemExit('ERROR: Cannot load specified %s file' % args.load_servers)     
+        
+        file = args.load_servers[0]
+    else:
+        file = None
+
     if args.list:
         try:
-            speedtest.get_servers()
+            speedtest.get_servers(load_servers=file)
         except (ServersRetrievalError,) + HTTP_ERRORS:
             printer('Cannot retrieve speedtest server list', error=True)
             raise SpeedtestCLIError(get_exception())
@@ -1916,7 +1935,7 @@ def shell():
     if not args.mini:
         printer('Retrieving speedtest.net server list...', quiet)
         try:
-            speedtest.get_servers(servers=args.server, exclude=args.exclude)
+            speedtest.get_servers(servers=args.server, exclude=args.exclude, load_servers=file)
         except NoMatchedServers:
             raise SpeedtestCLIError(
                 'No matched servers: %s' %


### PR DESCRIPTION
In some cases, you need to do tests against the same server each time, but if this server is not available in the get_servers list, then speedtest does not know where the server is.

Example:
- I want always use the server with id 4243
```<server url="https://speedtest.vc.shawcable.net:8080/speedtest/upload.php" lat="49.2505" lon="-123.1119" name="Vancouver, BC" country="Canada" cc="CA" sponsor="Shaw Communications" id="4243" host="speedtest.vc.shawcable.net:8080"/>```

- but it's not available in the list anymore:
```$ ./speedtest.py --list
Retrieving speedtest.net configuration...
51693) Ziply Fiber (Bothell, WA, United States) [164.12 km]
29820) Bluespan (Easton, WA, United States) [245.09 km]
15300) iFIBER Communications (Ephrata, WA, United States) [310.60 km]
57671) Advanced Internet (Yakima, WA, United States) [331.10 km]
38364) Vyve Broadband (Moses Lake, WA, United States) [339.71 km]
10166) CenturyLink (Spokane, WA, United States) [420.54 km]
27449) Cutting Edge Communications, Inc (Spokane, WA, United States) [420.54 km]
36007) Gonzaga University (Spokane, WA, United States) [420.54 km]
21227) xyTel Inc (Kennewick, WA, United States) [425.06 km]
 3126) Pendleton Fiber (Pendleton, OR, United States) [488.51 km]
```

- it's the server is not in the returned list of servers, speedtest can't use it:
```
$ ./speedtest.py --server 4243
Retrieving speedtest.net configuration...
Testing from Shaw Communications (###.###.###.###)...
Retrieving speedtest.net server list...
ERROR: No matched servers: 4243
```
- with `--load-servers` option, I can load server settings from the file:
```
$ ./speedtest.py --load-servers server-list.txt --server 4243
Retrieving speedtest.net configuration...
Loading file with servers...
Testing from Shaw Communications (###.###.###.###)...
Retrieving speedtest.net server list...
Retrieving information for the selected server...
Hosted by Shaw Communications (Vancouver, BC) [35.99 km]: 55.018 ms
Testing download speed................................................................................
Download: 105.36 Mbit/s
Testing upload speed................................................................................................
Upload: 93.00 Mbit/s
```

**Note:** 
1. currently get_servers still executing and servers from the file are added to the list
1. may be `--save-servers` will be a good option