### PR TITLE
Set secure connection as default

### DIFF
--- a/speedtest.py
+++ b/speedtest.py
@@ -946,7 +946,7 @@ class SpeedtestResults(object):
     """
 
     def __init__(self, download=0, upload=0, ping=0, server=None, client=None,
-                 opener=None, secure=False):
+                 opener=None, secure=True):
         self.download = download
         self.upload = upload
         self.ping = ping
@@ -1087,7 +1087,7 @@ class Speedtest(object):
     """Class for performing standard speedtest.net testing operations"""
 
     def __init__(self, config=None, source_address=None, timeout=10,
-                 secure=False, shutdown_event=None):
+                 secure=True, shutdown_event=None):
         self.config = {}
 
         self._source_address = source_address
@@ -1770,8 +1770,8 @@ def parse_args():
     parser.add_argument('--source', help='Source IP address to bind to')
     parser.add_argument('--timeout', default=10, type=PARSER_TYPE_FLOAT,
                         help='HTTP timeout in seconds. Default 10')
-    parser.add_argument('--secure', action='store_true',
-                        help='Use HTTPS instead of HTTP when communicating '
+    parser.add_argument('--insecure', action='store_true', default=False,
+                        help='Use HTTP instead of HTTPS when communicating '
                              'with speedtest.net operated servers')
     parser.add_argument('--no-pre-allocate', dest='pre_allocate',
                         action='store_const', default=True, const=False,
@@ -1885,7 +1885,7 @@ def shell():
         speedtest = Speedtest(
             source_address=args.source,
             timeout=args.timeout,
-            secure=args.secure
+            secure=not args.insecure
         )
     except (ConfigRetrievalError,) + HTTP_ERRORS:
         printer('Cannot retrieve speedtest configuration', error=True)


### PR DESCRIPTION
Speedtest servers don't support HTTP connections anymore so I renamed the `--secure` parameter to `--insecure` and set it to False by default.