### PR TITLE
change .utcnow() to .now(datetime.UTC) (deprecated)

### DIFF
--- a/speedtest.py
+++ b/speedtest.py
@@ -957,7 +957,7 @@ class SpeedtestResults(object):
         self.client = client or {}
 
         self._share = None
-        self.timestamp = '%sZ' % datetime.datetime.utcnow().isoformat()
+        self.timestamp = '%sZ' % datetime.datetime.now(datetime.UTC).isoformat()
         self.bytes_received = 0
         self.bytes_sent = 0
 


### PR DESCRIPTION
When i run command speedtest-cli on my MacBook(Sonoma14.1.1) with Python3.12.
```bash
❯ speedtest-cli
Retrieving speedtest.net configuration...
/opt/homebrew/bin/speedtest-cli:960: DeprecationWarning: datetime.datetime.utcnow() is deprecated and scheduled for removal in a future version. Use timezone-aware objects to represent datetimes in UTC: datetime.datetime.now(datetime.UTC).
  self.timestamp = '%sZ' % datetime.datetime.utcnow().isoformat()
```
This method will be deprecated in future versions of python-datetime and it is recommended to change it now. Thank you.