### PR TITLE
remove deprecated method in python3.12

### DIFF
--- a/speedtest.py
+++ b/speedtest.py
@@ -957,7 +957,12 @@ class SpeedtestResults(object):
         self.client = client or {}
 
         self._share = None
-        self.timestamp = '%sZ' % datetime.datetime.utcnow().isoformat()
+        # datetime.datetime.utcnow() is deprecated starting from 3.12
+        # but datetime.UTC is supported starting from 3.11
+        if sys.version_info.major >= 3 and sys.version_info.minor >= 11:
+            self.timestamp = '%sZ' % datetime.datetime.now(datetime.UTC).isoformat()
+        else:
+            self.timestamp = '%sZ' % datetime.datetime.utcnow().isoformat()
         self.bytes_received = 0
         self.bytes_sent = 0
 


### PR DESCRIPTION
Because `datetime.datetime.utcnow()` was marked deprecated in 3.12, but `datetime.UTC` was only supported from 3.11. In order to ensure usability, I used `sys.version_info` to check the current version to apply to lower versions of python. I tested in `python2.7`, `python 3.8`, `python3.11` and `python3.12` respectively, and they were all in line with expectations.