### PR TITLE
Use timezone-aware datetime.datetime.now()

### DIFF
--- a/speedtest.py
+++ b/speedtest.py
@@ -957,7 +957,7 @@ class SpeedtestResults(object):
         self.client = client or {}
 
         self._share = None
-        self.timestamp = '%sZ' % datetime.datetime.utcnow().isoformat()
+        self.timestamp = '%sZ' % datetime.datetime.now(datetime.timezone.utc).isoformat()
         self.bytes_received = 0
         self.bytes_sent = 0
 


### PR DESCRIPTION
Replace deprecated datetime.datetime.utcnow() with timezone-aware datetime.datetime.now()

This change addresses a deprecation warning for python 3.12 by using datetime.datetime.now() with datetime.timezone.utc, ensuring the timestamp remains in UTC and conforms to newer best practices.
