### PR TITLE
Update speedtest.py line 960

### DIFF
--- a/speedtest.py
+++ b/speedtest.py
@@ -957,7 +957,7 @@ class SpeedtestResults(object):
         self.client = client or {}
 
         self._share = None
-        self.timestamp = '%sZ' % datetime.datetime.utcnow().isoformat()
+        self.timestamp = '%sZ' % datetime.datetime.now(datetime.UTC).isoformat()
         self.bytes_received = 0
         self.bytes_sent = 0
 


### PR DESCRIPTION
❯ speedtest
Retrieving speedtest.net configuration...
/opt/homebrew/bin/speedtest:960: DeprecationWarning: datetime.datetime.utcnow() is deprecated and scheduled for removal in a future version. Use timezone-aware objects to represent datetimes in UTC: datetime.datetime.now(datetime.UTC).
  self.timestamp = '%sZ' % datetime.datetime.utcnow().isoformat()