### PR TITLE
resolved the deprecation

### DIFF
--- a/speedtest.py
+++ b/speedtest.py
@@ -957,7 +957,7 @@ class SpeedtestResults(object):
         self.client = client or {}
 
         self._share = None
-        self.timestamp = '%sZ' % datetime.datetime.utcnow().isoformat()
+        self.timestamp = datetime.datetime.now(datetime.timezone.utc).isoformat()
         self.bytes_received = 0
         self.bytes_sent = 0
 


### PR DESCRIPTION
```py
<stdin>:960: DeprecationWarning: datetime.datetime.utcnow() is deprecated and scheduled for removal in a future version. Use timezone-aware objects to represent datetimes in UTC: datetime.datetime.now(datetime.UTC).
```
fixed it with "datetime.datetime.now(datetime.timezone.utc)"