### PR TITLE
Change URL for getting servers to the JS API one (the previous ones tend to respond with 429)

### DIFF
--- a/speedtest.py
+++ b/speedtest.py
@@ -742,6 +742,7 @@ def catch_request(request, opener=None):
         return uh, False
     except HTTP_ERRORS:
         e = get_exception()
+        printer('Error: %s' % e, debug=True)
         return None, e
 
 
@@ -1259,10 +1260,7 @@ class Speedtest(object):
                     )
 
         urls = [
-            '://www.speedtest.net/speedtest-servers-static.php',
-            'http://c.speedtest.net/speedtest-servers-static.php',
-            '://www.speedtest.net/speedtest-servers.php',
-            'http://c.speedtest.net/speedtest-servers.php',
+            "://www.speedtest.net/api/js/servers",
         ]
 
         headers = {}
@@ -1305,53 +1303,31 @@ class Speedtest(object):
                 printer('Servers XML:\n%s' % serversxml, debug=True)
 
                 try:
-                    try:
-                        try:
-                            root = ET.fromstring(serversxml)
-                        except ET.ParseError:
-                            e = get_exception()
-                            raise SpeedtestServersError(
-                                'Malformed speedtest.net server list: %s' % e
-                            )
-                        elements = etree_iter(root, 'server')
-                    except AttributeError:
-                        try:
-                            root = DOM.parseString(serversxml)
-                        except ExpatError:
-                            e = get_exception()
-                            raise SpeedtestServersError(
-                                'Malformed speedtest.net server list: %s' % e
-                            )
-                        elements = root.getElementsByTagName('server')
-                except (SyntaxError, xml.parsers.expat.ExpatError):
+                    elements = json.loads(serversxml)
+                except SyntaxError:
                     raise ServersRetrievalError()
 
                 for server in elements:
-                    try:
-                        attrib = server.attrib
-                    except AttributeError:
-                        attrib = dict(list(server.attributes.items()))
-
-                    if servers and int(attrib.get('id')) not in servers:
+                    if servers and int(server.get('id')) not in servers:
                         continue
 
-                    if (int(attrib.get('id')) in self.config['ignore_servers']
-                            or int(attrib.get('id')) in exclude):
+                    if (int(server.get('id')) in self.config['ignore_servers']
+                            or int(server.get('id')) in exclude):
                         continue
 
                     try:
                         d = distance(self.lat_lon,
-                                     (float(attrib.get('lat')),
-                                      float(attrib.get('lon'))))
+                                     (float(server.get('lat')),
+                                      float(server.get('lon'))))
                     except Exception:
                         continue
 
-                    attrib['d'] = d
+                    server['d'] = d
 
                     try:
-                        self.servers[d].append(attrib)
+                        self.servers[d].append(server)
                     except KeyError:
-                        self.servers[d] = [attrib]
+                        self.servers[d] = [server]
 
                 break
 


### PR DESCRIPTION
This PR is a "clone" of [that PR](https://github.com/sivel/speedtest-cli/pull/796), where only the part that actually make up the fix has been kept — as opposed to all the reformatting included in the original PR.